### PR TITLE
Disable AIO by default

### DIFF
--- a/init/Kconfig
+++ b/init/Kconfig
@@ -1350,7 +1350,6 @@ config SHMEM
 
 config AIO
 	bool "Enable AIO support"
-	default y
 	help
 	  This option enables POSIX asynchronous I/O which may by used
 	  by some high performance threaded applications. Disabling

--- a/init/Kconfig
+++ b/init/Kconfig
@@ -1349,7 +1349,7 @@ config SHMEM
 	  which may be appropriate on small systems without swap.
 
 config AIO
-	bool "Enable AIO support" if EXPERT
+	bool "Enable AIO support"
 	default y
 	help
 	  This option enables POSIX asynchronous I/O which may by used


### PR DESCRIPTION
This PR allows disabling AIO by default for linux-hardened kernel. It's based on CopperheadOS recommendation [1]. If it's accepted feel free to apply it under your name and ordinary kernel patch layout.

[1] https://copperhead.co/android/docs/technical_overview#attack-surface-reduction